### PR TITLE
Use safe allocation methods for Buffer instances

### DIFF
--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -45,7 +45,7 @@ class Encoder extends Transform {
   _transform( data, encoding, done ) {
     const json = `${ JSON.stringify( data ) }\n`;
     const byteLength = Buffer.byteLength( json, 'utf8' );
-    const buffer = new Buffer( byteLength + 8 );
+    const buffer = Buffer.alloc( byteLength + 8 );
 
     buffer.writeUInt32LE( Encoder.HEADER, 0 );
     buffer.writeUInt32LE( byteLength, 4 );

--- a/lib/header.js
+++ b/lib/header.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = new Buffer('JSON').readUInt32LE( 0 );
+module.exports = Buffer.from('JSON').readUInt32LE( 0 );

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -31,14 +31,32 @@ class Parser extends Transform {
     // amount of filled bytes in the buffer
     this._bOffset = 0;
     // temporary buffer for header + length
-    this._hBuf = new Buffer( 8 );
+    this._hBuf = Buffer.alloc( 8 );
     // amount of filled bytes in the header buffer
     this._hOffset = 0;
-    // stream.Readable looks for bound listeners to `data` to set
-    // its internal `_readableStateflowing` flag, which we need in order
-    // for the internal `_readableState.buffer` to be appropriately drained,
-    // so we can't just emit the custom `message` event on `push`
-    this.on( 'data', this._ondata );
+  }
+
+  /**
+   * stream.Readable treats `data` as a "magic" event name and automatically
+   * resumes the stream when a `data` handler is bound.
+   *
+   * Since we want to allow missive users to bind only to `message` (without
+   * needing to subscribe to `data`), we do the same thing with
+   * `message` handlers.
+   *
+   * @param  {String} ev – event name
+   * @param  {String} fn – callback function
+   * @return {Parser}
+   */
+
+  on( ev, fn ) {
+    let res = super.on( ev, fn );
+
+    if ( ev === 'message' && !this.isPaused() ) {
+      this.resume();
+    }
+
+    return res;
   }
 
   /**
@@ -59,7 +77,7 @@ class Parser extends Transform {
     let length = chunk.length;
 
     if ( typeof chunk === 'string' ) {
-      chunk = new Buffer( chunk, encoding || 'utf8' );
+      chunk = Buffer.from( chunk, encoding || 'utf8' );
     }
 
     while ( true ) {
@@ -123,7 +141,7 @@ class Parser extends Transform {
    */
 
   _startMessage() {
-    this._buffer = new Buffer( this._bufLen );
+    this._buffer = Buffer.alloc( this._bufLen );
     this._bOffset = 0;
     this._hOffset = 0;
   }
@@ -198,7 +216,7 @@ class Parser extends Transform {
   }
 
   /**
-   * Override native `push` to do some cleanup first.
+   * Override native `push` to do some cleanup and emit `message` events
    *
    * This is the method that actually makes data readable via `pipe()`
    * or `.on( 'data' )`.
@@ -210,18 +228,7 @@ class Parser extends Transform {
   push( buffer ) {
     this._clear();
     super.push( buffer );
-  }
-
-  /**
-   * Emit a custom `message` event that sends a parsed JS object
-   * instead of a Buffer instance
-   *
-   * @param  {Object} json – buffer
-   * @return {Undefined}
-   */
-
-  _ondata( json ) {
-    this.emit( 'message', JSON.parse( json.toString('utf8') ) );
+    this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );
   }
 
   /**


### PR DESCRIPTION
Also improves the way we emit `message` events.

Previously, we were binding to `data` inside the `Parser` constructor. This had the unfortunate effect of unpausing the stream immediately, regardless of whether or not anyone was actually listening to `data` events.

In theory, this meant that message received _prior_ to additional `data`/`message` handlers being bound may be essentially lost. That is, we would emit a `data` event and clear the internal buffer without anyone ever having "heard" about it.

The new approach treats `message` the same way as `stream.Readable` treats `data`, which is that it automatically resumes the stream when a handler is bound. This means that `Parser` streams will generate backpressure now, where they may not have previously.