### PR TITLE
Add benchmark task + perf improvements

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -10,7 +10,9 @@ module.exports = function( grunt ) {
     // mocha tests
     mocha_istanbul: require('./build/config/mocha'),
     // watch config
-    watch: require('./build/config/watch')
+    watch: require('./build/config/watch'),
+    // benchmark config
+    benchmark: require('./build/config/benchmark')
   });
 
   // load npm plugins (all dependencies that match /^grunt/)

--- a/build/benchmarks/encode.js
+++ b/build/benchmarks/encode.js
@@ -1,0 +1,20 @@
+let Encoder = require('../../lib/encoder');
+let encoder = new Encoder();
+
+let data = { foo: 'bar', baz: 'bing' };
+
+// make sure the stream isn't paused so that it
+// won't buffer all these messages
+encoder.resume();
+
+module.exports = {
+  name: 'Encode',
+  tests: [
+    {
+      name: 'Encode',
+      fn() {
+        encoder.write( data );
+      }
+    }
+  ]
+};

--- a/build/benchmarks/parse.js
+++ b/build/benchmarks/parse.js
@@ -1,0 +1,26 @@
+let Encoder = require('../../lib/encoder');
+let Parser = require('../../lib/parser');
+let encoder = new Encoder();
+let parser = new Parser();
+
+let data = { foo: 'bar', baz: 'bing' };
+
+encoder.write( data );
+
+let msg = encoder.read();
+
+// make sure the stream isn't paused so that it
+// won't buffer all these messages
+parser.resume();
+
+module.exports = {
+  name: 'Parse',
+  tests: [
+    {
+      name: 'Parse',
+      fn() {
+        parser.write( msg );
+      }
+    }
+  ]
+};

--- a/build/config/benchmark.js
+++ b/build/config/benchmark.js
@@ -1,0 +1,5 @@
+module.exports = {
+  all: {
+    src: [ 'build/benchmarks/*.js']
+  }
+};

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -45,7 +45,7 @@ class Encoder extends Transform {
   _transform( data, encoding, done ) {
     const json = `${ JSON.stringify( data ) }\n`;
     const byteLength = Buffer.byteLength( json, 'utf8' );
-    const buffer = new Buffer( byteLength + 8 );
+    const buffer = Buffer.alloc( byteLength + 8 );
 
     buffer.writeUInt32LE( Encoder.HEADER, 0 );
     buffer.writeUInt32LE( byteLength, 4 );

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -45,7 +45,7 @@ class Encoder extends Transform {
   _transform( data, encoding, done ) {
     const json = `${ JSON.stringify( data ) }\n`;
     const byteLength = Buffer.byteLength( json, 'utf8' );
-    const buffer = Buffer.alloc( byteLength + 8 );
+    const buffer = Buffer.allocUnsafe( byteLength + 8 ).fill( 0 );
 
     buffer.writeUInt32LE( Encoder.HEADER, 0 );
     buffer.writeUInt32LE( byteLength, 4 );

--- a/lib/header.js
+++ b/lib/header.js
@@ -1,3 +1,3 @@
 'use strict';
 
-module.exports = new Buffer('JSON').readUInt32LE( 0 );
+module.exports = Buffer.from('JSON').readUInt32LE( 0 );

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -141,7 +141,9 @@ class Parser extends Transform {
    */
 
   _startMessage() {
-    this._buffer = Buffer.alloc( this._bufLen );
+    // allocUnsafe + fill is faster than alloc because `unsafe`
+    // will grab memory from the buffer pool, but alloc won't
+    this._buffer = Buffer.allocUnsafe( this._bufLen ).fill( 0 );
     this._bOffset = 0;
     this._hOffset = 0;
   }
@@ -228,7 +230,10 @@ class Parser extends Transform {
   push( buffer ) {
     this._clear();
     super.push( buffer );
-    this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );
+    // don't pay for JSON parsing if nobody's listening
+    if ( this.listenerCount('message') !== 0 ) {
+      this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );
+    }
   }
 
   /**

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -31,14 +31,32 @@ class Parser extends Transform {
     // amount of filled bytes in the buffer
     this._bOffset = 0;
     // temporary buffer for header + length
-    this._hBuf = new Buffer( 8 );
+    this._hBuf = Buffer.alloc( 8 );
     // amount of filled bytes in the header buffer
     this._hOffset = 0;
-    // stream.Readable looks for bound listeners to `data` to set
-    // its internal `_readableStateflowing` flag, which we need in order
-    // for the internal `_readableState.buffer` to be appropriately drained,
-    // so we can't just emit the custom `message` event on `push`
-    this.on( 'data', this._ondata );
+  }
+
+  /**
+   * stream.Readable treats `data` as a "magic" event name and automatically
+   * resumes the stream when a `data` handler is bound.
+   *
+   * Since we want to allow missive users to bind only to `message` (without
+   * needing to subscribe to `data`), we do the same thing with
+   * `message` handlers.
+   *
+   * @param  {String} ev – event name
+   * @param  {String} fn – callback function
+   * @return {Parser}
+   */
+
+  on( ev, fn ) {
+    let res = super.on( ev, fn );
+
+    if ( ev === 'message' && !this.isPaused() ) {
+      this.resume();
+    }
+
+    return res;
   }
 
   /**
@@ -59,7 +77,7 @@ class Parser extends Transform {
     let length = chunk.length;
 
     if ( typeof chunk === 'string' ) {
-      chunk = new Buffer( chunk, encoding || 'utf8' );
+      chunk = Buffer.from( chunk, encoding || 'utf8' );
     }
 
     while ( true ) {
@@ -123,7 +141,7 @@ class Parser extends Transform {
    */
 
   _startMessage() {
-    this._buffer = new Buffer( this._bufLen );
+    this._buffer = Buffer.alloc( this._bufLen );
     this._bOffset = 0;
     this._hOffset = 0;
   }
@@ -198,7 +216,7 @@ class Parser extends Transform {
   }
 
   /**
-   * Override native `push` to do some cleanup first.
+   * Override native `push` to do some cleanup and emit `message` events
    *
    * This is the method that actually makes data readable via `pipe()`
    * or `.on( 'data' )`.
@@ -210,18 +228,7 @@ class Parser extends Transform {
   push( buffer ) {
     this._clear();
     super.push( buffer );
-  }
-
-  /**
-   * Emit a custom `message` event that sends a parsed JS object
-   * instead of a Buffer instance
-   *
-   * @param  {Object} json – buffer
-   * @return {Undefined}
-   */
-
-  _ondata( json ) {
-    this.emit( 'message', JSON.parse( json.toString('utf8') ) );
+    this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );
   }
 
   /**

--- a/package.json
+++ b/package.json
@@ -2,7 +2,13 @@
   "name": "missive",
   "version": "1.0.2",
   "description": "Fast, lightweight library for encoding and decoding JSON messages over streams.",
-  "keywords": [ "json", "stream", "streams", "streaming", "tcp" ],
+  "keywords": [
+    "json",
+    "stream",
+    "streams",
+    "streaming",
+    "tcp"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/StarryInternet/missive"
@@ -16,6 +22,7 @@
     "eslint-config-starry": "2.0.0",
     "eslint-plugin-starry": "2.0.0",
     "grunt": "0.4.5",
+    "grunt-benchmark": "1.0.0",
     "grunt-cli": "0.1.13",
     "grunt-contrib-jshint": "0.11.2",
     "grunt-contrib-watch": "0.6.1",
@@ -39,7 +46,9 @@
       "name": "Stephen Murray"
     }
   ],
-  "engines": { "node": ">=4.0.0" },
+  "engines": {
+    "node": ">=4.0.0"
+  },
   "scripts": {
     "test": "grunt"
   },


### PR DESCRIPTION
`allocUnsafe().fill()` is faster than `alloc()`, because the unsafe allocation will grab memory from the buffer pool and the safe allocation won't: https://nodejs.org/api/buffer.html#buffer_class_method_buffer_allocunsafe_size

Note that `allocUnsafe()` immediately followed by `fill()` is perfectly safe. This is just a perf hack that allows me to grab memory from the pre-allocated buffer pool. I'm manually zeroing these out.

Also skip JSON parsing when nobody has asked for it.


____
May have merge conflicts after #1 gets merged.