### PR TITLE
Prevent calling "toString" on null

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -231,7 +231,7 @@ class Parser extends Transform {
     this._clear();
     super.push( buffer );
     // don't pay for JSON parsing if nobody's listening
-    if ( this.listenerCount('message') !== 0 ) {
+    if ( buffer && this.listenerCount('message') !== 0 ) {
       this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );
     }
   }


### PR DESCRIPTION
Under some circumstances, push might be called with null, e.g. denoting end of a stream.
In this case, the null can not be converted to string and parsed and would lead to an uncaught TypeError.