### PR TITLE
Support inflate/deflate via zlib

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,27 @@ client.pipe( missive.parse() ).on( 'message', function( obj ) {
 });
 ```
 
+##### Compression
+
+To enable Node's `zlib` compression, instantiate an `encode` stream
+with `{ deflate: true }` and a `parse` stream with `{ inflate: true }`
+
+Note that this will incur a fairly substantial performance penalty, so
+compression is only advised in situations where message volume is low
+and saving bytes over the wire is critical.
+
+```js
+let missive = require('missive');
+let encode = missive.encode({ deflate: true });
+let parse = missive.parse({ inflate: true });
+
+parse.on( 'message', function( obj ) {
+  console.log( obj.foo ); // 'bar'
+});
+
+encode.write({ foo: 'bar' });
+```
+
 ### Spec
 
 In case you can't use `missive` on one side of a socket, this is

--- a/build/benchmarks/deflate.js
+++ b/build/benchmarks/deflate.js
@@ -1,0 +1,20 @@
+let Encoder = require('../../lib/encoder');
+let encoder = new Encoder({ deflate: true });
+
+let data = { foo: 'bar', baz: 'bing' };
+
+// make sure the stream isn't paused so that it
+// won't buffer all these messages
+encoder.resume();
+
+module.exports = {
+  name: 'Encode (deflate)',
+  tests: [
+    {
+      name: 'Encode (deflate)',
+      fn() {
+        encoder.write( data );
+      }
+    }
+  ]
+};

--- a/build/benchmarks/inflate.js
+++ b/build/benchmarks/inflate.js
@@ -1,0 +1,26 @@
+let Encoder = require('../../lib/encoder');
+let Parser = require('../../lib/parser');
+let encoder = new Encoder({ deflate: true });
+let parser = new Parser({ inflate: true });
+
+let data = { foo: 'bar', baz: 'bing' };
+
+encoder.write( data );
+
+let msg = encoder.read();
+
+// make sure the stream isn't paused so that it
+// won't buffer all these messages
+parser.resume();
+
+module.exports = {
+  name: 'Parse (inflate)',
+  tests: [
+    {
+      name: 'Parse (inflate)',
+      fn() {
+        parser.write( msg );
+      }
+    }
+  ]
+};

--- a/index.js
+++ b/index.js
@@ -3,5 +3,5 @@
 const Parser  = require('./lib/parser');
 const Encoder = require('./lib/encoder');
 
-module.exports.parse = () => new Parser();
-module.exports.encode = () => new Encoder();
+module.exports.parse = opts => new Parser( opts );
+module.exports.encode = opts => new Encoder( opts );

--- a/lib/encoder.js
+++ b/lib/encoder.js
@@ -2,6 +2,7 @@
 
 const Transform = require('stream').Transform;
 const HEADER    = require('./header');
+const zlib      = require('zlib');
 
 /**
  * Encoder class.
@@ -24,9 +25,13 @@ class Encoder extends Transform {
    * @return {Encoder}
    */
 
-  constructor() {
+  constructor( opts = {} ) {
     // call parent constructor (allow passing objects)
     super({ objectMode: true });
+
+    if ( opts.deflate ) {
+      this._deflate = zlib.deflate;
+    }
   }
 
   /**
@@ -43,13 +48,20 @@ class Encoder extends Transform {
    */
 
   _transform( data, encoding, done ) {
-    const json = `${ JSON.stringify( data ) }\n`;
-    const byteLength = Buffer.byteLength( json, 'utf8' );
+    const enc = this._deflate ? 'base64' : 'utf8';
+
+    let json = `${ JSON.stringify( data ) }\n`;
+
+    if ( this._deflate ) {
+      json = zlib.deflateSync( json ).toString( enc );
+    }
+
+    const byteLength = Buffer.byteLength( json, enc );
     const buffer = Buffer.allocUnsafe( byteLength + 8 ).fill( 0 );
 
     buffer.writeUInt32LE( Encoder.HEADER, 0 );
     buffer.writeUInt32LE( byteLength, 4 );
-    buffer.write( json, 8 );
+    buffer.write( json, 8, enc );
 
     this.push( buffer );
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -2,6 +2,7 @@
 
 const Transform = require('stream').Transform;
 const HEADER    = require('./header');
+const zlib      = require('zlib');
 const MAX_LEN   = 1024 * 1024;
 
 /**
@@ -21,7 +22,7 @@ class Parser extends Transform {
    * @return {Parser}
    */
 
-  constructor() {
+  constructor( opts = {} ) {
     // call parent constructor
     super();
     // buffered JSON data
@@ -34,6 +35,10 @@ class Parser extends Transform {
     this._hBuf = Buffer.alloc( 8 );
     // amount of filled bytes in the header buffer
     this._hOffset = 0;
+
+    if ( opts.inflate ) {
+      this._inflate = opts.inflate;
+    }
   }
 
   /**
@@ -229,7 +234,13 @@ class Parser extends Transform {
 
   push( buffer ) {
     this._clear();
+
+    if ( this._inflate ) {
+      buffer = zlib.inflateSync( buffer );
+    }
+
     super.push( buffer );
+
     // don't pay for JSON parsing if nobody's listening
     if ( buffer !== null && this.listenerCount('message') !== 0 ) {
       this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );

--- a/test/tests/parser.js
+++ b/test/tests/parser.js
@@ -39,6 +39,23 @@ describe( 'Parser', function() {
       encoder.write( obj );
     });
 
+    it( 'should deflate/inflate messages', function( done ) {
+      var Parser = require('rewire')('../../lib/parser'),
+        Encoder = require('rewire')('../../lib/encoder'),
+        parser = new Parser({ inflate: true }),
+        encoder = new Encoder({ deflate: true }),
+        obj = { foo: 'bar' };
+
+      encoder.pipe( parser ).on( 'message', function( msg ) {
+        chai.assert.equal( msg.foo, 'bar' );
+        // make sure it didn't just pass me back the same actual object
+        chai.assert.notEqual( msg, obj );
+        done();
+      });
+
+      encoder.write( obj );
+    });
+
     it( 'should accept strings', function( done ) {
       var Parser = require('rewire')('../../lib/parser'),
         Encoder = require('rewire')('../../lib/encoder'),


### PR DESCRIPTION
Note: I chose synchronous inflate/deflate here in order to avoid branched expectations on read/write.

Prior to the inclusion of compression, writes and reads in missive were always synchronous. By making reads and writes async for compression, we'd (potentially) make it significally more difficult for users to enable compression without the need to refactor their applications.

An example of this is creating a single, shared `encode()` stream that is used to encode messages for *all* sockets. This is way more efficient than creating an `encode()` stream per socket.

In those cases, it's convienient to be able to write to `encode()` and then synchronously `encode.read()` to retrieve the encoded buffer.

So, anyway -- the point is that I didn't want to break that with the zlib add.