### PR TITLE
don't try to inflate null

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -235,6 +235,10 @@ class Parser extends Transform {
   push( buffer ) {
     this._clear();
 
+    if ( buffer === null ) {
+      return super.push( buffer );
+    }
+
     if ( this._inflate ) {
       buffer = zlib.inflateSync( buffer );
     }
@@ -242,7 +246,7 @@ class Parser extends Transform {
     super.push( buffer );
 
     // don't pay for JSON parsing if nobody's listening
-    if ( buffer !== null && this.listenerCount('message') !== 0 ) {
+    if ( this.listenerCount('message') !== 0 ) {
       this.emit( 'message', JSON.parse( buffer.toString('utf8') ) );
     }
   }

--- a/test/tests/parser.js
+++ b/test/tests/parser.js
@@ -326,6 +326,29 @@ describe( 'Parser', function() {
       encoder.write( obj );
     });
 
+    it( 'should emit `end` when `null` is pushed and inflate is enabled', function( done ) {
+      var Parser = require('rewire')('../../lib/parser'),
+        Encoder = require('rewire')('../../lib/encoder'),
+        parser = new Parser({ inflate: true }),
+        encoder = new Encoder({ deflate: true }),
+        obj = { foo: 'bar' };
+
+      // bind a message to make sure we trigger the null check
+      parser.on( 'message', () => {} );
+
+      encoder.on( 'data', function( chunk ) {
+        parser.on( 'end', () => {
+          chai.assert.ok( true );
+          done();
+        });
+
+        parser.write( chunk );
+        parser.push( null );
+      });
+
+      encoder.write( obj );
+    });
+
   });
 
 });


### PR DESCRIPTION
The `null` push to signal end-of-stream caused a `TypeError` when `inflate` was enabled on a `Parser` stream.